### PR TITLE
Updates to run on perl 5.8

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -2,8 +2,6 @@
 use strict;
 use warnings;
 
-use 5.010;
-
 use ExtUtils::MakeMaker;
 
 my %WriteMakefileArgs = (
@@ -14,7 +12,7 @@ my %WriteMakefileArgs = (
   },
   "DISTNAME" => "Authen-U2F",
   "LICENSE" => "perl",
-  "MIN_PERL_VERSION" => "5.010",
+  "MIN_PERL_VERSION" => "5.008",
   "NAME" => "Authen::U2F",
   "PREREQ_PM" => {
     "Carp" => 0,

--- a/dist.ini
+++ b/dist.ini
@@ -25,7 +25,7 @@ die_on_line_insertion   = 1
 issues = 1
 
 [TravisYML]
-perl_version = -5.8 5.10 5.12 5.14 5.16 5.18 5.20 5.22 5.24 -blead
+perl_version = 5.8 5.10 5.12 5.14 5.16 5.18 5.20 5.22 5.24 -blead
 
 [@Git]
 tag_format = %v

--- a/examples/demoserver/demoserver.psgi
+++ b/examples/demoserver/demoserver.psgi
@@ -1,6 +1,5 @@
 #!/usr/bin/env plackup
 
-use 5.010;
 use warnings;
 use strict;
 
@@ -25,9 +24,10 @@ my $base_app = sub {
   return $req->new_response(404)->finalize unless $file && -r "$file.html.tt2";
 
   my $template = do { local (@ARGV, $/) = ("$file.html.tt2"); <> };
+  my $u2f = defined $env->{u2f} ? $env->{u2f} : {};
   $t->process(\$template, {
     %$session,
-    u2f => $env->{u2f} // {},
+    u2f => $u2f,
   }, \my $output) || die $t->error;
 
   my $res = $req->new_response(200);

--- a/examples/register.pl
+++ b/examples/register.pl
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
 
-use 5.010;
 use warnings;
 use strict;
 
@@ -10,17 +9,19 @@ use JSON;
 use constant APPID   => 'https://example.com';
 use constant VERSION => 'U2F_V2';
 
-say "CHALLENGE:";
+print "CHALLENGE:\n";
 
 my $challenge = Authen::U2F->challenge;
-say encode_json({
+print encode_json({
   challenge => $challenge,
   appId     => APPID,
   version   => VERSION,
-});
+}) . "\n";
 
-say "";
-say "ENTER RESPONSE:";
+exit;
+
+print "\n";
+print "ENTER RESPONSE:\n";
 chomp (my $in = <STDIN>);
 
 my $reg_response = decode_json($in);
@@ -33,6 +34,6 @@ my ($handle, $key) = Authen::U2F->registration_verify(
   client_data       => $reg_response->{clientData},
 );
 
-say "";
-say "HANDLE: $handle";
-say "KEY: $key";
+print "\n";
+print "HANDLE: $handle\n";
+print "KEY: $key\n";

--- a/examples/sign.pl
+++ b/examples/sign.pl
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
 
-use 5.010;
 use warnings;
 use strict;
 
@@ -15,18 +14,18 @@ unless ($handle && $key) {
   die "usage: $0 <handle> <key>\n";
 }
 
-say "CHALLENGE:";
+print "CHALLENGE:\n";
 
 my $challenge = Authen::U2F->challenge;
-say encode_json({
+print encode_json({
   challenge => $challenge,
   keyHandle => $handle,
   appId     => APPID,
   version   => VERSION,
-});
+}) . "\n";
 
-say "";
-say "ENTER RESPONSE:";
+print "\n";
+print "ENTER RESPONSE:\n";
 chomp (my $in = <STDIN>);
 
 my $sign_response = decode_json($in);
@@ -41,5 +40,5 @@ Authen::U2F->signature_verify(
   client_data    => $sign_response->{clientData},
 );
 
-say "";
-say "SUCCESS";
+print "\n";
+print "SUCCESS\n";

--- a/lib/Authen/U2F.pm
+++ b/lib/Authen/U2F.pm
@@ -2,7 +2,6 @@ package Authen::U2F;
 
 # ABSTRACT: FIDO U2F library
 
-use 5.010;
 use warnings;
 use strict;
 
@@ -28,11 +27,16 @@ sub u2f_challenge           { __PACKAGE__->challenge(@_) }
 sub u2f_registration_verify { __PACKAGE__->registration_verify(@_) }
 sub u2f_signature_verify    { __PACKAGE__->signature_verify(@_) }
 
+# Param checks
+my $challenge_check;
+my $registration_check;
+my $signature_check;
+
 sub challenge {
-  state $check = compile(
+  $challenge_check ||= compile(
     ClassName,
   );
-  my ($class) = $check->(@_);
+  my ($class) = $challenge_check->(@_);
 
   my $raw = pack "L*", map { irand } 1..8;
   my $challenge = encode_base64url($raw);
@@ -40,7 +44,7 @@ sub challenge {
 }
 
 sub registration_verify {
-  state $check = compile(
+  $registration_check ||= compile(
     ClassName,
     slurpy Dict[
       challenge         => Str,
@@ -50,7 +54,7 @@ sub registration_verify {
       client_data       => Str,
     ],
   );
-  my ($class, $args) = $check->(@_);
+  my ($class, $args) = $registration_check->(@_);
 
   my $client_data = decode_base64url($args->{client_data});
   croak "couldn't decode client data; not valid Base64-URL?"
@@ -135,7 +139,7 @@ sub registration_verify {
 }
 
 sub signature_verify {
-  state $check = compile(
+  $signature_check ||= compile(
     ClassName,
     slurpy Dict[
       challenge      => Str,
@@ -147,7 +151,7 @@ sub signature_verify {
       client_data    => Str,
     ],
   );
-  my ($class, $args) = $check->(@_);
+  my ($class, $args) = $signature_check->(@_);
 
   my $key = decode_base64url($args->{key});
   croak "couldn't decode key; not valid Base64-URL?"


### PR DESCRIPTION
We would like to use this for Pobox, but it needed some minor changes to run on perl 5.8 (most substantially, taking the pretty `state` variables for param checking and making them rather uglier closures with `$state ||= compile(...)`.